### PR TITLE
Add missing dependancy

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -9,3 +9,7 @@ externals:
     Libs/LibSerialize: https://github.com/rossnichols/LibSerialize
     Libs/AceAddon-3.0: https://repos.wowace.com/wow/ace3/trunk/AceAddon-3.0
     Libs/AceEvent-3.0: https://repos.wowace.com/wow/ace3/trunk/AceEvent-3.0
+    Libs/AceConsole-3.0: https://repos.wowace.com/wow/ace3/trunk/AceConsole-3.0
+    Libs/AceHook-3.0: https://repos.wowace.com/wow/ace3/trunk/AceHook-3.0
+    Libs/AceDB-3.0: https://repos.wowace.com/wow/ace3/trunk/AceDB-3.0
+

--- a/Libs/embeds.xml
+++ b/Libs/embeds.xml
@@ -2,4 +2,9 @@
   <Script file="Libs\LibStub\LibStub.lua"/>
   <Include file="Libs\LibDeflate/lib.xml"/>
   <Include file="Libs\LibSerialize/lib.xml"/>
+  <Include file="Libs\AceAddon-3.0/AceAddon-3.0.xml"/>
+  <Include file="Libs\AceEvent-3.0/AceEvent-3.0.xml"/>
+  <Include file="Libs\AceConsole-3.0/AceConsole-3.0.xml"/>
+  <Include file="Libs\AceHook-3.0/AceHook-3.0.xml"/>
+  <Include file="Libs\AceDB-3.0/AceDB-3.0.xml"/>
 </Ui>


### PR DESCRIPTION
Hello,
After installing the addon from curse, I saw the addon having missing dependency.
Addon version used: 3.3.2

So I made the needed change.

I hope the .pkgmeta have the good format and this pull request can help you. :)